### PR TITLE
DE-13722: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS
+# This file defines code ownership and review requirements for this repository.
+# For more information, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# All files require review from repository teams by default
+*                @resonate/full-stack-avengers @resonate/mobile
+
+# All GitHub metadata and workflows
+.github/           @resonate/devops-shield
+.github/**         @resonate/devops-shield
+
+# Docker definitions
+Dockerfile         @resonate/devops-shield
+**/\[Dd\]ockerfile*  @resonate/devops-shield
+**/*.dockerfile    @resonate/devops-shield
+
+# Terraform & HCL
+**/*.tf            @resonate/devops-shield
+**/*.hcl           @resonate/devops-shield


### PR DESCRIPTION
## Description
This PR adds a CODEOWNERS file to establish code review requirements for this repository.

## Changes
- Added `.github/CODEOWNERS` file
- DevOps and infrastructure files require review from @resonate/devops-shield:
  - All GitHub metadata and workflows (`.github/` and `.github/**`)
  - Docker definitions (`Dockerfile`, `**/[Dd]ockerfile*`, `**/*.dockerfile`)
  - Terraform & HCL files (`**/*.tf`, `**/*.hcl`)
- All other files require review from the teams assigned to this repository

## References
- Jira: DE-13722
- [GitHub CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
